### PR TITLE
Fix for proper unpack from a XIB and retaining position

### DIFF
--- a/RateView/RateView.m
+++ b/RateView/RateView.m
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2014 Tarun Tyagi
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,7 +28,7 @@
 
 @interface Star : UIView
 {
-    
+
 }
 //color - Normal Background Color (Unfilled)
 @property(nonatomic,strong)UIColor* color;
@@ -78,16 +78,16 @@
         // By default, background doesn't have any color
         self.backgroundColor = [UIColor clearColor];
         self.clipsToBounds = YES;
-        
+
         // Assign the color, fillColor & other defaults
         _color = color;
         _fillColor = fillColor;
         _borderColor = DefaultBorderColor;
-        
+
         _fillMode = StarFillModeHorizontal;
         _currentValue = 0.0f;
     }
-    
+
     return self;
 }
 
@@ -100,13 +100,13 @@
     // Get Current Context & Clear for transparent background
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextClearRect(context, rect);
-    
+
     /*
-     * We expect a square for the 'rect', 
+     * We expect a square for the 'rect',
      * so arm = rect.size.width = rect.size.height
      */
     CGFloat arm = rect.size.width;
-    
+
     // Create a path for star shape
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathMoveToPoint(path, NULL, arm*0.0, arm*0.35);
@@ -120,7 +120,7 @@
     CGPathAddLineToPoint(path, NULL, arm*0.15, arm*1.00);
     CGPathAddLineToPoint(path, NULL, arm*0.25, arm*0.60);
     CGPathAddLineToPoint(path, NULL, arm*0.0, arm*0.35);
-    
+
     /*
      * Add this path's copy(Only for border) to context, stroke it for the border to appear.
      * Add the original path to context, Clip the context for this path.
@@ -135,23 +135,23 @@
     CGContextSetLineWidth(context, 1);
     CGContextSetStrokeColorWithColor(context, _borderColor.CGColor);
     CGContextStrokePath(context);
-    
+
     CGContextAddPath(context, path);
     CGContextClip(context);
-    
+
     // Fill the color in Star for regular backgroundColor
     CGContextSetFillColorWithColor(context, _color.CGColor);
     CGContextFillRect(context, rect);
-    
+
     // Decide where to start filling & upto where it's gonna be
     CGPoint source = CGPointZero;
     CGPoint destination = CGPointZero;
-    
+
     if(_fillMode == StarFillModeHorizontal)
     {
         // left arm mid point
         source = CGPointMake(0, arm/2);
-        
+
         // progress x++
         destination = CGPointMake(_currentValue*arm, arm/2);
     }
@@ -159,7 +159,7 @@
     {
         // bottom arm mid point
         source = CGPointMake(arm/2, arm);
-        
+
         // progress y--
         destination = CGPointMake(arm/2, arm - _currentValue*arm);
     }
@@ -167,7 +167,7 @@
     {
         // bottom left corner
         source = CGPointMake(0, arm);
-        
+
         /*
          * progress should be y-- (arm - _currentValue*arm)
          * but have to fix instead, it goes diagonally very fast
@@ -183,21 +183,21 @@
          * it's the closest I could get to it.
          * Needs further refinement.
          */
-        
+
         if(_currentValue > 0.0f)
             destination = CGPointMake((_currentValue*arm)/1.07, arm - (_currentValue*arm)/sqrt(2));
         else
             destination = source;
     }
-    
+
     /*
      * Set fillColor to stroke color,
      * line width thick enough to cover every possible corner of the star
      */
     CGContextSetStrokeColorWithColor(context, _fillColor.CGColor);
     CGContextSetLineWidth(context, 2*arm);
-    
-    /* 
+
+    /*
      * Add a very thick line from source to destination
      * line's thickness will cover the entire star width
      * giving us the required fill
@@ -206,10 +206,10 @@
     CGContextMoveToPoint(context, source.x, source.y);
     CGContextAddLineToPoint(context, destination.x, destination.y);
     CGContextClosePath(context);
-    
+
     // Stroke the line
     CGContextStrokePath(context);
-    
+
     // Restore Context State
     CGContextRestoreGState(context);
 
@@ -295,16 +295,26 @@
     return [[self alloc] initWithRating:rating];
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    return [self initWithRating:0 andFrame:self.frame];
+}
+
 -(id)initWithRating:(float)rating
 {
-    if(self = [super initWithFrame:DefaultRateViewFrame])
+    return [self initWithRating:rating andFrame:DefaultRateViewFrame];
+}
+
+-(id)initWithRating:(float)rating andFrame:(CGRect)newFrame
+{
+    if(self = [super initWithFrame:newFrame])
     {
         self.backgroundColor = [UIColor clearColor];
-        
+
         _rating = rating;
-        
+
         _step = 0.0f;
-        
+
         // Check Rating Max / Min
         if(_rating > MaximumRating)
         {
@@ -318,21 +328,21 @@
                   "You can't have rating less than 0.0, Making it 0.0 for now");
             _rating = MinimumRating;
         }
-        
+
         //Assign default values to required properties
         _canRate = NO;
-        
+
         _starNormalColor = DefaultStarNormalColor;
         _starFillColor = DefaultStarFillColor;
         _starBorderColor = DefaultStarBorderColor;
-        
+
         _starFillMode = StarFillModeHorizontal;
         _starSize = DefaultStarSize;
-        
+
         //Call setRating: so that view's UI gets updated
         self.rating = rating;
     }
-    
+
     return self;
 }
 
@@ -341,7 +351,7 @@
     // Update frame for self to accommodate desired width for 5 stars
     self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y,
                             5*_starSize, _starSize);
-    
+
     // Check if stars have been added to self previously or not
     if([self.subviews count] == 0)
     {
@@ -364,12 +374,12 @@
 {
     _rating = rating;
     [self updateRateView];
-    
+
     // Update Stars appearance for currentValue
     for(int i=1; i<=5; i++)
     {
         Star* star = (Star*)[self viewWithTag:TagOffset+i];
-        
+
         if(_rating >= i)
         {
             star.currentValue = 1.0f;
@@ -380,7 +390,7 @@
             star.currentValue = (expectedRating < 0.0f) ? 0.0f : expectedRating;
         }
     }
-    
+
     // Notify the delegate object about rating change
     if([_delegate respondsToSelector:@selector(rateView:didUpdateRating:)])
         [_delegate rateView:self didUpdateRating:_rating];
@@ -408,7 +418,7 @@
 {
     _starNormalColor = starNormalColor;
     [self updateRateView];
-    
+
     // Update Stars appearance for color
     for(int i=1; i<=5; i++)
     {
@@ -421,7 +431,7 @@
 {
     _starFillColor = starFillColor;
     [self updateRateView];
-    
+
     // Update Stars appearance for fillColor
     for(int i=1; i<=5; i++)
     {
@@ -434,7 +444,7 @@
 {
     _starBorderColor = starBorderColor;
     [self updateRateView];
-    
+
     // Update Stars appearance for borderColor
     for(int i=1; i<=5; i++)
     {
@@ -447,7 +457,7 @@
 {
     _starFillMode = starFillMode;
     [self updateRateView];
-    
+
     // Update Stars appearance for fillMode
     for(int i=1; i<=5; i++)
     {
@@ -460,7 +470,7 @@
 {
     _starSize = starSize;
     [self updateRateView];
-    
+
     // Update Stars appearance for size
     for(int i=1; i<=5; i++)
     {
@@ -478,7 +488,7 @@
         frame.size.width = 5*_starSize;
         frame.size.height = _starSize;
     }
-    
+
     [super setFrame:frame];
 }
 


### PR DESCRIPTION
Basically, it overrides the initWithCoder method to read the position
given in the XIB, then passes on the frame to the slightly changed
constructor (that can now accept a frame), this allows the RateView
to retain the position from the XIB and properly initialize everything
else.

Apologies for the whitespace trim spam, but the changes are so few
that it shouldn't be a problem noticing what's changed.